### PR TITLE
Reduce bundle size by removing unused images

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -3,11 +3,11 @@ import { Glob } from "glob";
 import esbuild from "esbuild";
 import { copy } from "jsr:@std/fs";
 
-function globCopy(glob: Glob<{ withFileTypes: true }>, dist: string) {
-  glob.stream().on("data", async (path) => {
+async function globCopy(glob: Glob<{ withFileTypes: true }>, dist: string) {
+  for await (const path of glob) {
     console.log(path.fullpath())
     await Deno.copyFile(path.fullpath(), `${dist}/${path.name}`);
-  });
+  }
 }
 
 const srcDir = "src";
@@ -41,7 +41,7 @@ await esbuild.build({
 
 Deno.mkdir("dist/images", { recursive: true });
 
-globCopy(
+await globCopy(
   new Glob([
     `${srcDir}/*.html`,
     `${srcDir}/*.css`,
@@ -52,7 +52,7 @@ globCopy(
   `${distDir}/`,
 );
 
-globCopy(
+await globCopy(
   new Glob([`${srcDir}/images/*-*.png`], { withFileTypes: true }),
   `${distDir}/images`,
 );

--- a/build.ts
+++ b/build.ts
@@ -7,11 +7,13 @@ async function globCopy(glob: Glob<{ withFileTypes: true }>, dist: string) {
   for await (const path of glob) {
     console.log(path.fullpath());
     try {
-      await Deno.copyFile(path.fullpath(), `${dist}/${path.name}`)
+      await Deno.copyFile(path.fullpath(), `${dist}/${path.name}`);
     } catch (err) {
-      console.error(`Failed to copy ${path.fullpath()} to ${dist}/${path.name}`)
-      console.error(err)
-    };
+      console.error(
+        `Failed to copy ${path.fullpath()} to ${dist}/${path.name}`,
+      );
+      throw err;
+    }
   }
 }
 

--- a/build.ts
+++ b/build.ts
@@ -6,7 +6,12 @@ import { copy } from "jsr:@std/fs";
 async function globCopy(glob: Glob<{ withFileTypes: true }>, dist: string) {
   for await (const path of glob) {
     console.log(path.fullpath());
-    await Deno.copyFile(path.fullpath(), `${dist}/${path.name}`);
+    try {
+      await Deno.copyFile(path.fullpath(), `${dist}/${path.name}`)
+    } catch (err) {
+      console.error(`Failed to copy ${path.fullpath()} to ${dist}/${path.name}`)
+      console.error(err)
+    };
   }
 }
 

--- a/build.ts
+++ b/build.ts
@@ -5,7 +5,7 @@ import { copy } from "jsr:@std/fs";
 
 async function globCopy(glob: Glob<{ withFileTypes: true }>, dist: string) {
   for await (const path of glob) {
-    console.log(path.fullpath())
+    console.log(path.fullpath());
     await Deno.copyFile(path.fullpath(), `${dist}/${path.name}`);
   }
 }

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,8 +1,10 @@
 /// <reference types="chrome"/>
 // YouTube Shorts Limiter - Background Script
 
-import browser from "webextension-polyfill";
+import type Browser from "webextension-polyfill";
 import type { Message } from "./types.ts";
+
+declare const browser: typeof Browser;
 
 // Кросс-браузерный доступ к API
 const ext =

--- a/src/content.ts
+++ b/src/content.ts
@@ -1,7 +1,10 @@
 // deno-lint-ignore-file require-await
 // YouTube Shorts Limiter - Content Script
-import browser from "webextension-polyfill";
+
+import type Browser from "webextension-polyfill";
 import type { Message, Settings } from "./types.ts";
+
+declare const browser: typeof Browser;
 
 const ext = (typeof chrome !== "undefined" ? chrome : browser) as typeof chrome;
 const getMessage = ext.i18n.getMessage;

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -81,8 +81,8 @@ class PopupManager {
       },
     );
 
-    setInterval(() => {
-      this.loadData();
+    setInterval(async () => {
+      await this.loadData();
       this.updateUI();
       console.log("Refreshed data");
     }, 2000);

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -82,9 +82,14 @@ class PopupManager {
     );
 
     setInterval(async () => {
-      await this.loadData();
-      this.updateUI();
-      console.log("Refreshed data");
+      try {
+        await this.loadData();
+        this.updateUI();
+        console.log("Refreshed data");
+      } catch (err) {
+        console.error(err);
+        console.log("Failed to refresh data");
+      }
     }, 2000);
   }
 

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -1,11 +1,13 @@
 /// <reference types="chrome"/>
 // // YouTube Shorts Limiter - Popup Script
 
-import browser from "webextension-polyfill";
 import type { GenericSettings, Settings } from "./types.ts";
+import type Browser from "webextension-polyfill";
+
+declare const browser: typeof Browser;
 
 const ext =
-  (typeof chrome !== "undefined" ? chrome : browser) as typeof browser;
+  (typeof chrome !== "undefined" ? chrome : browser) as typeof Browser;
 
 const getMessage = ext.i18n.getMessage;
 

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -83,6 +83,7 @@ class PopupManager {
 
     setInterval(() => {
       this.loadData();
+      this.updateUI();
       console.log("Refreshed data");
     }, 2000);
   }


### PR DESCRIPTION
currently, build script copies all files from images/ to extension's bundle, but icon.png, which is also biggest file in extension, is not used anywhere and icon-128.png (or images of smaller sizes) is used instead, with this change bundle size got reduced by 1.5 mb